### PR TITLE
keep bin/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 *.aux
 *.dvi
 *.pdf
-bin/
 old/
 test/
 test_of_mcd.txt


### PR DESCRIPTION
Makefile assumes that there is bin/ directory on build root.