### PR TITLE
Make SATySFi installable by opam again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,20 +38,20 @@ preliminary:
 
 lib:
 # -- downloads UNIDATA --
-	wget http://www.unicode.org/Public/UNIDATA/EastAsianWidth.txt       -O lib-satysfi/dist/unidata/EastAsianWidth.txt
-	wget http://www.unicode.org/Public/UNIDATA/LineBreak.txt            -O lib-satysfi/dist/unidata/LineBreak.txt
-	wget http://www.unicode.org/Public/UNIDATA/PropList.txt             -O lib-satysfi/dist/unidata/PropList.txt
-	wget http://www.unicode.org/Public/UNIDATA/PropertyAliases.txt      -O lib-satysfi/dist/unidata/PropertyAliases.txt
-	wget http://www.unicode.org/Public/UNIDATA/PropertyValueAliases.txt -O lib-satysfi/dist/unidata/PropertyValueAliases.txt
-	wget http://www.unicode.org/Public/UNIDATA/Scripts.txt              -O lib-satysfi/dist/unidata/Scripts.txt
-	wget http://www.unicode.org/Public/UNIDATA/ScriptExtensions.txt     -O lib-satysfi/dist/unidata/ScriptExtensions.txt
-	wget http://www.unicode.org/Public/UNIDATA/UnicodeData.txt          -O lib-satysfi/dist/unidata/UnicodeData.txt
+	wget -N http://www.unicode.org/Public/UNIDATA/EastAsianWidth.txt       -P lib-satysfi/dist/unidata/
+	wget -N http://www.unicode.org/Public/UNIDATA/LineBreak.txt            -P lib-satysfi/dist/unidata/
+	wget -N http://www.unicode.org/Public/UNIDATA/PropList.txt             -P lib-satysfi/dist/unidata/
+	wget -N http://www.unicode.org/Public/UNIDATA/PropertyAliases.txt      -P lib-satysfi/dist/unidata/
+	wget -N http://www.unicode.org/Public/UNIDATA/PropertyValueAliases.txt -P lib-satysfi/dist/unidata/
+	wget -N http://www.unicode.org/Public/UNIDATA/Scripts.txt              -P lib-satysfi/dist/unidata/
+	wget -N http://www.unicode.org/Public/UNIDATA/ScriptExtensions.txt     -P lib-satysfi/dist/unidata/
+	wget -N http://www.unicode.org/Public/UNIDATA/UnicodeData.txt          -P lib-satysfi/dist/unidata/
 # -- downloads fonts --
 	mkdir -p temp/
-	wget http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip -O temp/lm2.004otf.zip
-	unzip temp/lm2.004otf.zip -d lib-satysfi/dist/fonts/
-	wget http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip -O temp/latinmodern-math-1959.zip
-	unzip temp/latinmodern-math-1959.zip -d temp/
+	wget -N http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip -P temp/
+	unzip -o temp/lm2.004otf.zip -d lib-satysfi/dist/fonts/
+	wget -N http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip -P temp/
+	unzip -o temp/latinmodern-math-1959.zip -d temp/
 	cp temp/latinmodern-math-1959/otf/latinmodern-math.otf lib-satysfi/dist/fonts/
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -20,20 +20,21 @@ all:
 install: $(TARGET)
 	mkdir -p $(BINDIR)
 	install $(TARGET) $(BINDIR)
+	install -d $(PREFIX_LIB)/lib-satysfi
+	install -d $(PREFIX_LIB)/lib-satysfi/dist
+	install -d $(PREFIX_LIB)/lib-satysfi/dist/unidata
+	install -m 644 lib-satysfi/dist/unidata/*.txt $(PREFIX_LIB)/lib-satysfi/dist/unidata
+	install -d $(PREFIX_LIB)/lib-satysfi/dist/fonts
+	install -m 644 lib-satysfi/dist/fonts/* $(PREFIX_LIB)/lib-satysfi/dist/fonts
+	install -d $(PREFIX_LIB)/lib-satysfi/dist/hash
+	install -m 644 lib-satysfi/dist/hash/* $(PREFIX_LIB)/lib-satysfi/dist/hash
+	install -d $(PREFIX_LIB)/lib-satysfi/dist/hyph
+	install -m 644 lib-satysfi/dist/hyph/* $(PREFIX_LIB)/lib-satysfi/dist/hyph
+	install -d $(PREFIX_LIB)/lib-satysfi/dist/packages
+	install -m 644 lib-satysfi/dist/packages/* $(PREFIX_LIB)/lib-satysfi/dist/packages
 
 preliminary:
-	opam install -y ppx_deriving
-	opam install -y menhir
-	opam install -y core.v0.9.1
-	opam install -y ctypes
-	opam install -y uutf
-	opam install -y result
-	opam install -y bitv
-	opam install -y batteries
-	opam install -y yojson
-	opam install -y camlimages
-	eval `opam config env`
-	git submodule update -i
+	[ -d .git ] && git submodule update -i || echo "Skip git submodule update -i"
 
 lib:
 # -- downloads UNIDATA --
@@ -52,11 +53,10 @@ lib:
 	wget http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip -O temp/latinmodern-math-1959.zip
 	unzip temp/latinmodern-math-1959.zip -d temp/
 	cp temp/latinmodern-math-1959/otf/latinmodern-math.otf lib-satysfi/dist/fonts/
-# -- make a symbolic link for libraries --
-	ln -s -i `pwd`/lib-satysfi $(PREFIX_LIB)/lib-satysfi
 
 uninstall:
 	rm -rf $(BINDIR)/$(TARGET)
+	rm -rf $(PREFIX_LIB)/lib-satysfi
 
 clean:
 	$(OCB) -clean

--- a/opam
+++ b/opam
@@ -7,17 +7,31 @@ homepage: "https://github.com/gfngfn/Macrodown"
 dev-repo: "https://github.com/gfngfn/Macrodown.git"
 bug-reports: "https://github.com/gfngfn/Macrodown/issues"
 build: [
-  [make "-f" "Makefile" "preliminary" "PREFIX=%{prefix}"]
-  [make "-f" "Makefile" "PREFIX=%{prefix}%"]
-  [make "-f" "Makefile" "lib" "PREFIX=%{prefix}%"]
+  [make "-f" "Makefile" "preliminary" "PREFIX=%{prefix}%" "PREFIX_LIB=%{prefix}%"]
+  [make "-f" "Makefile" "PREFIX=%{prefix}%" "PREFIX_LIB=%{prefix}%"]
+  [make "-f" "Makefile" "lib" "PREFIX=%{prefix}%" "PREFIX_LIB=%{prefix}%"]
 ]
 install: [
-  [make "-f" "Makefile" "install" "PREFIX=%{prefix}%"]
+  [make "-f" "Makefile" "install" "PREFIX=%{prefix}%" "PREFIX_LIB=%{prefix}%"]
+]
+post-messages: [
+  "Please set SATYSFI_LIB_ROOT. You may want to add the following line to ~/.bashrc"
+  "export SATYSFI_LIB_ROOT=\"$(PREFIX_LIB)/lib-satysfi\""
 ]
 remove: [
-  [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%"]
+  [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "PREFIX_LIB=%{prefix}%"]
 ]
 depends: [
+  "ppx_deriving"
+  "menhir"
+  "core" {= "v0.9.1"}
+  "ctypes"
+  "uutf"
+  "result"
+  "bitv"
+  "batteries"
+  "yojson"
+  "camlimages"
   "ocamlfind"
   "ocamlbuild" {build}
   "menhir"


### PR DESCRIPTION
This pull request is to fix problems installing SATySFi with OPAM.

- Let OPAM install the depended libraries.
- Initialize git submodules only in git repo mode.
    - This makes it possible to pin the local repository as either `path` or `git` repo.
- Copy files rather than make a symbolic link during installation.
- Download unicode data files and fonts only when needed.
    - Useful for local development.

I still have the following error when I remove the package. I don't have an idea about properly removing an OPAM package yet. This pull request does not fix the problem during uninstallation.
```
$ opam pin remove macrodown
macrodown is now unpinned from git /Users/mrty/Documents/Development/Macrodown#HEAD
The following actions will be performed:
  ⊘  remove macrodown ~unknown
Do you want to continue ? [Y/n] y

=-=- Gathering sources =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=  🐫

=-=- Processing actions -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=  🐫
[WARNING] failure in package uninstall script, some files may remain:
          # opam-version 1.2.2
          # os           darwin
          # command      make -f Makefile uninstall PREFIX=/Users/mrty/.opam/4.05.0
          PREFIX_LIB=/Users/na4zagin3/.opam/4.05.0
          # path         /Users/na4zagin3/.opam/4.05.0/build/macrodown.~unknown
          # compiler     4.05.0
          # exit-code    2
          # env-file     /Users/na4zagin3/.opam/4.05.0/build/macrodown.~unknown/macrodown-83868-42bb52.env
          # stdout-file  /Users/na4zagin3/.opam/4.05.0/build/macrodown.~unknown/macrodown-83868-42bb52.out
          # stderr-file  /Users/na4zagin3/.opam/4.05.0/build/macrodown.~unknown/macrodown-83868-42bb52.err
          ### stderr ###
          # make: Makefile: No such file or directory
          # make: *** No rule to make target `Makefile'.  Stop.

⊘  removed   macrodown.~unknown
Done.
```